### PR TITLE
Reduce support to 10.9 and support automatic build for every night at 12.00

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check latest tag
         id: check_tag
         run: |
-          tag1=$(curl -s https://api.github.com/repos/MatsuriDayo/nekoray/releases/latest | jq -r '.tag_name')
+          tag1=$(curl -s https://api.github.com/repos/MatsuriDayo/nekoray/tags | jq -r '.[0].name')
           tag2=$(git describe --abbrev=0 --tags)
           echo "Latest tag on MatsuriDayo/nekoray: $tag1"
           echo "Latest tag on this repository: $tag2"
@@ -25,6 +25,7 @@ jobs:
           
   build:
     runs-on: macos-latest
+    needs: check_tag
 
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -16,7 +16,7 @@ jobs:
         id: check_tag
         run: |
           tag1=$(curl -s https://api.github.com/repos/MatsuriDayo/nekoray/tags | jq -r '.[0].name')
-          tag2=$(git describe --abbrev=0 --tags)
+          tag2=$(curl -s https://api.github.com/repos/Stevemoretz/nekoray-macos/tags | jq -r '.[0].name')
           echo "Latest tag on MatsuriDayo/nekoray: $tag1"
           echo "Latest tag on this repository: $tag2"
           if [[ "$tag1" == "$tag2" ]]; then

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -28,9 +28,6 @@ jobs:
     runs-on: macos-latest
     needs: check_tag
 
-    env:
-      MACOSX_DEPLOYMENT_TARGET: 10.15
-
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
       - name: Check latest tag
         id: check_tag
         run: |

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -16,7 +16,7 @@ jobs:
         id: check_tag
         run: |
           tag1=$(curl -s https://api.github.com/repos/MatsuriDayo/nekoray/tags | jq -r '.[0].name')
-          tag2=$(curl -s https://api.github.com/repos/Stevemoretz/nekoray-macos/tags | jq -r '.[0].name')
+          tag2=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/tags | jq -r '.[0].name')
           echo "Latest tag on MatsuriDayo/nekoray: $tag1"
           echo "Latest tag on this repository: $tag2"
           if [[ "$tag1" == "$tag2" ]]; then

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,10 +1,28 @@
 name: Build and Release Nekoray
 
 on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight UTC
   push:
     branches: [main]
 
 jobs:
+  check_tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check latest tag
+        id: check_tag
+        run: |
+          tag1=$(curl -s https://api.github.com/repos/MatsuriDayo/nekoray/releases/latest | jq -r '.tag_name')
+          tag2=$(git describe --abbrev=0 --tags)
+          echo "Latest tag on MatsuriDayo/nekoray: $tag1"
+          echo "Latest tag on this repository: $tag2"
+          if [[ "$tag1" == "$tag2" ]]; then
+            echo "Latest tags match! Aborting workflow."
+            exit 1
+          fi
+          
   build:
     runs-on: macos-latest
 

--- a/nekoray_macos_builder.sh
+++ b/nekoray_macos_builder.sh
@@ -47,6 +47,7 @@ export PATH="/usr/local/opt/qt@5/bin:$PATH"
 export LDFLAGS="-L/usr/local/opt/qt@5/lib"
 export CPPFLAGS="-I/usr/local/opt/qt@5/include"
 export PKG_CONFIG_PATH="/usr/local/opt/qt@5/lib/pkgconfig"
+export MACOSX_DEPLOYMENT_TARGET="10.9"
 
 nRoot="$(pwd)"
 nPath="$(pwd)/nekoray"


### PR DESCRIPTION
You can see how it works where there is a new tag available:
https://github.com/Stevemoretz/nekoray-macos/actions/runs/4723476018/jobs/8379478797

And how it just skips the build when there is no newer version available:
https://github.com/Stevemoretz/nekoray-macos/actions/runs/4723476018/jobs/8380285519

```
Latest tag on MatsuriDayo/nekoray: 2.25
Latest tag on this repository: 2.25
Latest tags match! Aborting workflow.
```

This will run every night at 12.00 and if there is any newer tag available at https://github.com/MatsuriDayo/nekoray it will automatically create the MacOS versions for it, it's as simple as that.