### PR TITLE
Automatic overwrite for the latest tag on push triggers, add basic test job

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -84,7 +84,8 @@ jobs:
           releases=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.latest_tag }})
           if [[ -n $releases && $releases != *"Not Found"* ]]; then
             echo "Release ${{env.latest_tag}} already exists, deleting..."
-            release_id=$(echo $releases | jq -r .[0].id)
+            release_id=$(echo $releases | jq -r .id)
+            release_id=$(echo $releases | jq -r '.[].id')
             curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/$release_id
             curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${{ env.latest_tag }}" || true
           fi

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -87,6 +87,7 @@ jobs:
             release_id=$(echo $releases | jq -r .id)
             curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/$release_id
             curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${{ env.latest_tag }}" || true
+            sleep 10
           fi
 
       - name: Create Release
@@ -99,6 +100,7 @@ jobs:
           release_name: ${{ env.latest_tag }} macOS
           body: Built on the original repository. ${{ env.latest_tag }}
           draft: false
+          published: true
           prerelease: ${{ contains(env.latest_tag, 'pre') }}
           
       - name: Upload Release Asset for amd64

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -49,7 +49,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [macos-10.15]
+        os: [ubuntu-latest]
         arch: [amd64]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           releases=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.latest_tag }})
           if [[ -n $releases ]]; then
-            echo "Release ${env.latest_tag} already exists, deleting..."
+            echo "Release ${{env.latest_tag}} already exists, deleting..."
             release_id=$(echo $releases | jq -r .[0].id)
             curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/$release_id
             curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${{ env.latest_tag }}" || true

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -49,8 +49,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        arch: [amd64]
+        os: [macos-10.15, macos-11, macos-12]
+        arch: [amd64, arm64]
 
     runs-on: ${{ matrix.os }}
     needs: build

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -76,19 +76,30 @@ jobs:
           echo "Latest tag is ${latest_tag}"
           echo "latest_tag=${latest_tag}" >> $GITHUB_ENV
 
-      - name: Create or Update Release
-        uses: marvinpinto/action-automatic-releases@latest
+      - name: Check if release already exists
+        id: check_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          releases=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.latest_tag }})
+          if [[ -n $releases ]]; then
+            echo "Release ${env.latest_tag} already exists, deleting..."
+            release_id=$(echo $releases | jq -r .[0].id)
+            curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/$release_id
+            curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${{ env.latest_tag }}" || true
+          fi
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.repository }}
           tag_name: ${{ env.latest_tag }}
           release_name: ${{ env.latest_tag }} macOS
-          body: |
-            Built on the original repository. ${{ env.latest_tag }}
+          body: Built on the original repository. ${{ env.latest_tag }}
+          draft: false
           prerelease: ${{ contains(env.latest_tag, 'pre') }}
-          delete_existing: false
           
       - name: Upload Release Asset for amd64
         id: upload_release_asset_amd64

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -46,9 +46,41 @@ jobs:
           name: nekoray_arm64
           path: nekoray/build/nekoray_arm64.zip
 
+  test:
+    strategy:
+      matrix:
+        os: [macos-10.15]
+        arch: [amd64]
+
+    runs-on: ${{ matrix.os }}
+    needs: build
+
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: nekoray_${{ matrix.arch }}
+          path: ./
+
+      - name: Unzip Artifact
+        run: |
+          unzip -q nekoray_${{ matrix.arch }}.zip
+          mv nekoray_${{ matrix.arch }}.app nekoray.app
+
+      - name: Run Nekoray
+        run: |
+          ./nekoray.app/Contents/MacOS/nekoray > nekoray.log 2>&1 &
+          nekoray_pid=$!
+          sleep 10
+          if ! ps -p "$nekoray_pid" > /dev/null; then
+            echo "Nekoray failed to stay open for 10 seconds."
+            cat nekoray.log
+            exit 1
+          fi
+
   create_release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: test
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   check_tag:
     runs-on: ubuntu-latest
-    if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@v2
       - name: Check latest tag

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check_tag:
     runs-on: ubuntu-latest
-
+    if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@v2
       - name: Check latest tag

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check latest tag
         id: check_tag
+        if: github.event_name != 'push'
         run: |
           tag1=$(curl -s https://api.github.com/repos/MatsuriDayo/nekoray/tags | jq -r '.[0].name')
           tag2=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/tags | jq -r '.[0].name')
@@ -75,6 +76,20 @@ jobs:
           latest_tag=$(git ls-remote --tags --sort=-v:refname https://github.com/MatsuriDayo/nekoray.git | head -n1 | awk '{print $2}' | sed 's/refs\/tags\///')
           echo "Latest tag is ${latest_tag}"
           echo "latest_tag=${latest_tag}" >> $GITHUB_ENV
+
+      - name: Check if release with same tag exists
+        id: check_release
+        uses: repo-sync/github-tag-action@v2.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.latest_tag }}
+          include_prereleases: true
+
+      - name: Delete existing release
+        if: steps.check_release.outputs.release_id != ''
+        run: |
+          echo "Deleting release with tag ${latest_tag}..."
+          curl -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/${{ steps.check_release.outputs.release_id }}
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -76,32 +76,20 @@ jobs:
           echo "Latest tag is ${latest_tag}"
           echo "latest_tag=${latest_tag}" >> $GITHUB_ENV
 
-      - name: Check if release with same tag exists
-        id: check_release
-        uses: repo-sync/github-tag-action@v2.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.latest_tag }}
-          include_prereleases: true
-
-      - name: Delete existing release
-        if: steps.check_release.outputs.release_id != ''
-        run: |
-          echo "Deleting release with tag ${latest_tag}..."
-          curl -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/${{ steps.check_release.outputs.release_id }}
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Create or Update Release
+        uses: marvinpinto/action-automatic-releases@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.repository }}
           tag_name: ${{ env.latest_tag }}
           release_name: ${{ env.latest_tag }} macOS
-          body: Built on the original repository. ${{ env.latest_tag }}
-          draft: false
+          body: |
+            Built on the original repository. ${{ env.latest_tag }}
           prerelease: ${{ contains(env.latest_tag, 'pre') }}
-
+          delete_existing: false
+          
       - name: Upload Release Asset for amd64
         id: upload_release_asset_amd64
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -85,7 +85,6 @@ jobs:
           if [[ -n $releases && $releases != *"Not Found"* ]]; then
             echo "Release ${{env.latest_tag}} already exists, deleting..."
             release_id=$(echo $releases | jq -r .id)
-            release_id=$(echo $releases | jq -r '.[].id')
             curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/$release_id
             curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${{ env.latest_tag }}" || true
           fi

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -82,7 +82,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           releases=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.latest_tag }})
-          if [[ -n $releases ]]; then
+          if [[ -n $releases && $releases != *"Not Found"* ]]; then
             echo "Release ${{env.latest_tag}} already exists, deleting..."
             release_id=$(echo $releases | jq -r .[0].id)
             curl -X DELETE -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/$release_id

--- a/nekoray_macos_builder.sh
+++ b/nekoray_macos_builder.sh
@@ -127,7 +127,7 @@ for cmd in "nekobox_core" "nekoray_core"; do
 done
 
 #zip nekoray by arch
-if [ -z "$GITHUB_ACTIONS" ]; then
+if [ -n "$GITHUB_ACTIONS" ]; then
   for arch in "amd64" "arm64"; do
     TEMP_PATH=$(pwd)
     cd "$nPath/build"

--- a/nekoray_macos_builder.sh
+++ b/nekoray_macos_builder.sh
@@ -128,7 +128,7 @@ done
 
 #zip nekoray by arch
 for arch in "amd64" "arm64"; do
-  zip -r "$nPath/build/nekoray_$arch.zip" "$nPath/build/nekoray_$arch.app"
+  zip -jr "$nPath/build/nekoray_$arch.zip" "$nPath/build/nekoray_$arch.app"
 done
 
 echo "Build finished and output files are in $nPath/build"

--- a/nekoray_macos_builder.sh
+++ b/nekoray_macos_builder.sh
@@ -128,7 +128,9 @@ done
 
 #zip nekoray by arch
 for arch in "amd64" "arm64"; do
-  zip -jr "$nPath/build/nekoray_$arch.zip" "$nPath/build/nekoray_$arch.app"
+  cd "$nPath/build"
+  zip -r "nekoray_$arch.zip" "nekoray_$arch.app"
+  cd -
 done
 
 echo "Build finished and output files are in $nPath/build"

--- a/nekoray_macos_builder.sh
+++ b/nekoray_macos_builder.sh
@@ -132,6 +132,18 @@ for arch in "amd64" "arm64"; do
   zip -r "nekoray_$arch.zip" "nekoray_$arch.app"
   cd -
 done
+if [ -z "$GITHUB_ACTIONS" ]; then
+  for arch in "amd64" "arm64"; do
+    TEMP_PATH=$(pwd)
+    cd "$nPath/build"
+    zip -r "nekoray_$arch.zip" "nekoray_$arch.app"
+    cd "$TEMP_PATH"
+  done
+else
+  for arch in "amd64" "arm64"; do
+    zip -r "$nPath/build/nekoray_$arch.zip" "$nPath/build/nekoray_$arch.app"
+  done
+fi
 
 echo "Build finished and output files are in $nPath/build"
 cd "$nPath"

--- a/nekoray_macos_builder.sh
+++ b/nekoray_macos_builder.sh
@@ -127,11 +127,6 @@ for cmd in "nekobox_core" "nekoray_core"; do
 done
 
 #zip nekoray by arch
-for arch in "amd64" "arm64"; do
-  cd "$nPath/build"
-  zip -r "nekoray_$arch.zip" "nekoray_$arch.app"
-  cd -
-done
 if [ -z "$GITHUB_ACTIONS" ]; then
   for arch in "amd64" "arm64"; do
     TEMP_PATH=$(pwd)


### PR DESCRIPTION
A better workflow:
<img width="895" alt="Screen Shot 1402-01-29 at 16 50 47" src="https://user-images.githubusercontent.com/27680142/232790336-03e150ff-e1aa-47c0-abef-2978d84fb632.png">
<img width="913" alt="Screen Shot 1402-01-29 at 16 53 07" src="https://user-images.githubusercontent.com/27680142/232790896-a2e9ef25-5d22-4920-a64e-6d1f7e1b65d5.png">
<img width="905" alt="Screen Shot 1402-01-29 at 16 53 32" src="https://user-images.githubusercontent.com/27680142/232791252-f43787bc-df58-46d2-b932-a3a0ffd68fd2.png">



Based on the conversation at:
https://github.com/aaaamirabbas/nekoray-macos/pull/7#issuecomment-1512175031

Here's how I fixed it, if you push any commits, the check_tag step gets ignored, because you always want to build with the latest commit, but overwrite the previous faulty releases is now automatic.

The schedule (Running at 12 every night) is untouched which means that check_tag would still run and only build a new version if there is a new version available on the main repository.

Then I added a basic test step to it, what it does is as simple as running the build before release to make sure it runs, it doesn't do anything else just opens the built package and runs it and I defined it to run on 10.15, 11, 12 for amd and arm which means 6 tests will run, if the app runs for 10 seconds and doesn't crash or get an error the test will pass, you can change the test later and make it fit to your needs.

Here's an example of how the test job could fail: https://github.com/Stevemoretz/nekoray-macos/actions/runs/4732578884/jobs/8399290331

I'm running the MacOS app on Ubuntu (on purpose) to see how it fails, and it worked and failed.

Here's the working example that worked for all 6 varients of MacOS 10.15, 11, 12 for amd and arm, of course since your build target is 10.9 you might want to add 10.9, 10.10, .... as well, just look in the workflow file and find the matrix section and add more OSes if you want.

<img width="913" alt="Screen Shot 1402-01-29 at 16 53 07" src="https://user-images.githubusercontent.com/27680142/232790896-a2e9ef25-5d22-4920-a64e-6d1f7e1b65d5.png">


----

This is a good starting point for your repository's CI, I leave the rest to you, you can add cache functionality to make your builds faster, you can improve the tests to do something better than just opening and checking for crash or errors you can get the actual body of release from the original repository and add it so every version comes with some decent description or add a link to each original release and ...

The possibilities are endless.